### PR TITLE
Reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,15 @@ Versionable can be configured in the Model that uses the Trait. Simply add the c
 
     // do not create a new version, when only these fields changed
     public $dontVersionFields = [ 'last_login_date' ];
+
+#### Optional field "reason"
+
+If you want to set a reason for each version, you can set this when filling a versionable Model:
+
+    protected $fillable = [/* more fields ...,*/ 'reason'];
+    
+    // in your Controller
+    $model->fill($request->only([/* more fields ...,*/ 'reason']));
+
+    // listing versions with reasons
+    echo $version->reason;

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -19,6 +19,23 @@ trait VersionableTrait
     private $versionableDirtyData;
 
     /**
+     * @var string
+     */
+    private $reason;
+
+    /**
+     * Attribute mutator for "reason"
+     * Prevent "reason" to become a database attribute of model
+     *
+     * @param string $value
+     */
+
+    public function setReasonAttribute($value)
+    {
+        $this->reason = $value;
+    }
+
+    /**
      * Initialize model events
      */
     public static function boot()
@@ -114,6 +131,11 @@ trait VersionableTrait
             $version->versionable_type  = get_class( $this );
             $version->user_id           = $this->getAuthUserId();
             $version->model_data        = serialize( $this->getAttributes() );
+
+            if (!empty($this->reason)) {
+                $version->reason = $this->reason;
+            }
+
             $version->save();
         }
     }

--- a/src/migrations/2015_03_13_213643_add_reason.php
+++ b/src/migrations/2015_03_13_213643_add_reason.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddReason extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('versions', function(Blueprint $table)
+		{
+            $table->string('reason', 100)->nullable()->after('model_data');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('versions', function(Blueprint $table)
+		{
+            $table->dropColumn('reason');
+		});
+	}
+
+}


### PR DESCRIPTION
I have added an optional field "reason" to versions. This can be filled on every save() of the versioned Model and helps to identify versions. Here is an example for entity "Script" from my application:

![versions](https://cloud.githubusercontent.com/assets/124634/6648314/b83340d2-c9d8-11e4-84ff-c8459ce8f5f4.png)
