### PR TITLE
remove unset versionableDirtyData

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -145,6 +145,7 @@ trait VersionableTrait
      */
     private function validForVersioning()
     {
+
         $versionableData = $this->versionableDirtyData;
         unset( $versionableData[ $this->getUpdatedAtColumn() ] );
         if( function_exists('getDeletedAtColumn') )
@@ -159,7 +160,7 @@ trait VersionableTrait
                 unset( $versionableData[ $fieldName ] );
             }
         }
-        unset( $this->versionableDirtyData );
+
         return ( count( $versionableData ) > 0 );
     }
 


### PR DESCRIPTION
In a specific case, the versionableDirtyData still exists in the update array in the Builder of Laraval.
Removing the unset of versionableDirtyData fix the issue.

``
[2015-06-23 14:20:43] testing.ERROR: exception 'ErrorException' with message 'preg_replace(): Parameter mismatch, pattern is a string while replacement is an array' in /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Support/helpers.php:674
Stack trace:
#0 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'preg_replace():...', '/private/var/ww...', 674, Array)
#1 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Support/helpers.php(674): preg_replace('/\\?/', Array, 'update `users` ...', 1)
#2 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/QueryException.php(56): str_replace_array('\\?', Array, 'update `users` ...')
#3 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/QueryException.php(39): Illuminate\Database\QueryException->formatMessage('update `users` ...', Array, Object(PDOException))
#4 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Connection.php(631): Illuminate\Database\QueryException->__construct('update `users` ...', Array, Object(PDOException))
#5 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Connection.php(589): Illuminate\Database\Connection->runQueryCallback('update `users` ...', Array, Object(Closure))
#6 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Connection.php(404): Illuminate\Database\Connection->run('update `users` ...', Array, Object(Closure))
#7 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Connection.php(347): Illuminate\Database\Connection->affectingStatement('update `users` ...', Array)
#8 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(1739): Illuminate\Database\Connection->update('update `users` ...', Array)
#9 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(311): Illuminate\Database\Query\Builder->update(Array)
#10 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1517): Illuminate\Database\Eloquent\Builder->update(Array)
#11 /private/var/www/sublime-adserver/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Model.php(1451): Illuminate\Database\Eloquent\Model->performUpdate(Object(Illuminate\Database\Eloquent\Builder), Array)
``