### PR TITLE
Lumen Support

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -37,7 +37,7 @@ class Version extends Eloquent
      */
     public function getResponsibleUserAttribute()
     {
-        $model = Config::get("auth.model");
+        $model = app('config')->get("auth.model");
         return $model::find($this->user_id);
     }
 

--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -37,7 +37,7 @@ class Version extends Eloquent
      */
     public function getResponsibleUserAttribute()
     {
-        $model = app('config')->get("auth.model");
+        $model = config("auth.model");
         return $model::find($this->user_id);
     }
 

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -187,8 +187,8 @@ trait VersionableTrait
      */
     private function getAuthUserId()
     {
-        if (Auth::check()) {
-            return Auth::id();
+        if (app('auth')->check()) {
+            return app('auth')->id();
         }
         return null;
     }

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -187,8 +187,8 @@ trait VersionableTrait
      */
     private function getAuthUserId()
     {
-        if (app('auth')->check()) {
-            return app('auth')->id();
+        if (auth()->check()) {
+            return auth()->id();
         }
         return null;
     }


### PR DESCRIPTION
I use Lumen and I want to use this versionable project but facades are not turned on by default. SO rather then turn on facades I think we should use the ioc container `app('auth')` rather then `Auth::` they do the same thing, just one is Facades and one directly accesses the IoC container.