### PR TITLE
Change getAuthUserId to protected

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -185,7 +185,7 @@ trait VersionableTrait
     /**
      * @return int|null
      */
-    private function getAuthUserId()
+    protected function getAuthUserId()
     {
         if (Auth::check()) {
             return Auth::id();


### PR DESCRIPTION
Okay so the other Lumen commit won't work as the tests don't include the core of the laravel/lumen (or illuminate/container) framework which is where the IoC stuff is so instead let's just set `getAuthUserId` to protected so I can overwrite it on my models.