### PR TITLE
Fix new version when touched by related model #11

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -148,7 +148,7 @@ trait VersionableTrait
          */
         if (
             ( $this->versioningEnabled === true && $this->updating && $this->isValidForVersioning() ) ||
-            ( $this->versioningEnabled === true && !$this->updating )
+            ( $this->versioningEnabled === true && !$this->updating && count($this->versionableDirtyData))
         ) {
             // Save a new version
             $version                   = new Version();


### PR DESCRIPTION
Fixes: When ModelA is be updated and touches ModelB the VersionableTrait
also creates a version for ModelB, even if it is not modified. Fix by
mk-conn, just packaged up into a pull request by geoffbeaumont.