### PR TITLE
Check for null before using count()

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -148,7 +148,7 @@ trait VersionableTrait
          */
         if (
             ( $this->versioningEnabled === true && $this->updating && $this->isValidForVersioning() ) ||
-            ( $this->versioningEnabled === true && !$this->updating && count($this->versionableDirtyData))
+            ( $this->versioningEnabled === true && !$this->updating && !is_null($this->versionableDirtyData) && count($this->versionableDirtyData))
         ) {
             // Save a new version
             $version                   = new Version();


### PR DESCRIPTION
This PR adds a check for `null` before using the `count()` method. Not having this was causing a number of my tests to fail once I switched to PHP 7.2. Below is the error that I was getting.

```ErrorException: count(): Parameter must be an array or an object that implements Countable```