### PR TITLE
Implement ServiceProvider for migration discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,14 @@
     "name": "mpociot/versionable",
     "license": "MIT",
     "description": "Allows to create Laravel 4 / 5 Model versioning and restoring",
-    "keywords": ["model", "laravel", "ardent", "version", "history", "restore"],
+    "keywords": [
+        "model",
+        "laravel",
+        "ardent",
+        "version",
+        "history",
+        "restore"
+    ],
     "homepage": "http://github.com/mpociot/versionable",
     "authors": [
         {
@@ -35,5 +42,12 @@
     },
     "scripts": {
         "test": "phpunit"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Mpociot\\Versionable\\Providers\\ServiceProvider"
+            ]
+        }
     }
 }

--- a/src/Mpociot/Providers/ServiceProvider.php
+++ b/src/Mpociot/Providers/ServiceProvider.php
@@ -22,6 +22,6 @@ class ServiceProvider extends LaravelServiceProvider
      */
     public function boot()
     {
-        $this->loadMigrationsFrom(__DIR__ . '/../migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../../migrations');
     }
 }

--- a/src/Mpociot/Providers/ServiceProvider.php
+++ b/src/Mpociot/Providers/ServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mpociot\Versionable\Providers\ServiceProvider;
+namespace Mpociot\Versionable\Providers;
 
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 

--- a/src/Mpociot/Providers/ServiceProvider.php
+++ b/src/Mpociot/Providers/ServiceProvider.php
@@ -22,6 +22,6 @@ class ServiceProvider extends LaravelServiceProvider
      */
     public function boot()
     {
-        $this->loadMigrationsFrom(__DIR__.'/../migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../migrations');
     }
 }

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mpociot\Versionable\Providers\ServiceProvider;
+
+use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
+
+class ServiceProvider extends LaravelServiceProvider
+{
+    /**
+     * Register bindings in the container.
+     *
+     * @return void
+     */
+    public function register ()
+    {
+    }
+
+    /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->loadMigrationsFrom(__DIR__.'/../migrations');
+    }
+}


### PR DESCRIPTION
Describe in the Laravel Docs[1] package migrations can be discovered by Composer when implementing a `ServiceProvider`.

[1] https://laravel.com/docs/5.6/packages#migrations