### PR TITLE
Use morphClassName

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -1,9 +1,11 @@
 <?php
 namespace Mpociot\Versionable;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
  * Class Version
@@ -51,7 +53,9 @@ class Version extends Eloquent
             ? stream_get_contents($this->model_data)
             : $this->model_data;
 
-        $model = new $this->versionable_type();
+        $class = Arr::get(Relation::morphMap(), $this->versionable_type, $this->versionable_type);
+
+        $model = new $class;
         $model->unguard();
         $model->fill(unserialize($modelData));
         $model->exists = true;

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -3,7 +3,6 @@ namespace Mpociot\Versionable;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Database\Eloquent\Concerns\HasRelationships;
 
 /**
  * Class VersionableTrait

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -3,6 +3,7 @@ namespace Mpociot\Versionable;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Concerns\HasRelationships;
 
 /**
  * Class VersionableTrait
@@ -173,7 +174,7 @@ trait VersionableTrait
             $class                     = $this->getVersionClass();
             $version                   = new $class();
             $version->versionable_id   = $this->getKey();
-            $version->versionable_type = get_class($this);
+            $version->versionable_type = $this->getMorphClass();
             $version->user_id          = $this->getAuthUserId();
             $version->model_data       = serialize($this->getAttributes());
 


### PR DESCRIPTION
The version model hardcodes the `versionable_type` attribute to the class name, but this is troublesome when using `Relation::morphMap()`.

Simple fix.