### PR TITLE
43 fix json column double encoding

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -175,7 +175,7 @@ trait VersionableTrait
             $version->versionable_id   = $this->getKey();
             $version->versionable_type = get_class($this);
             $version->user_id          = $this->getAuthUserId();
-            $version->model_data       = serialize($this->getAttributes());
+            $version->model_data       = serialize($this->attributesToArray());
 
             if (!empty( $this->reason )) {
                 $version->reason = $this->reason;

--- a/tests/VersionableTest.php
+++ b/tests/VersionableTest.php
@@ -289,6 +289,15 @@ class VersionableTest extends VersionableTestCase
 
     }
 
+    public function testGetVersionModelWithJsonField()
+    {
+        $model = new ModelWithJsonField();
+        $model->json_field = ["foo" => "bar"];
+        $model->save();
+
+        $this->assertEquals(["foo" => "bar"], $model->getVersionModel(1)->json_field);
+    }
+
     public function testUseReasonAttribute()
     {
         // Create 3 versions
@@ -546,5 +555,12 @@ class ModelWithDynamicVersion extends Model
     //use DynamicVersionModelTrait;
     use VersionableTrait ;
     protected $versionClass = DynamicVersionModel::class ;
+}
+class ModelWithJsonField extends Model
+{
+    const TABLENAME = 'table_with_json_field';
+    public $table = self::TABLENAME ;
+    use VersionableTrait ;
+    protected $casts = ['json_field' => 'array'];
 }
 

--- a/tests/VersionableTestCase.php
+++ b/tests/VersionableTestCase.php
@@ -65,5 +65,11 @@ abstract class VersionableTestCase extends \Orchestra\Testbench\TestCase
             $table->index('versionable_id');
             $table->timestamps();
         });
+
+        $this->app['db']->connection()->getSchemaBuilder()->create(ModelWithJsonField::TABLENAME, function ($table) {
+            $table->increments('id');
+            $table->json('json_field');
+            $table->timestamps();
+        });
     }
 }


### PR DESCRIPTION
Although with Postgres the current behavior is double-encoding JSON fields, the test case using SQLite will fail with "unable to serialize Closure" instead. Still, the change fixes the issue for both database systems.