### PR TITLE
Adds support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mpociot/versionable",
     "license": "MIT",
-    "description": "Allows to create Laravel 4 / 5 Model versioning and restoring",
+    "description": "Allows to create Laravel 4 / 5 / 6 Model versioning and restoring",
     "keywords": [
         "model",
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "source": "https://github.com/mpociot/versionable"
     },
     "require": {
-        "php": ">=7.1.0",
-        "illuminate/support": "~5.3"
+        "php": "    >=7.2.0",
+        "illuminate/support": "~5.3 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "7.*",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "source": "https://github.com/mpociot/versionable"
     },
     "require": {
-        "php": "    >=7.2.0",
+        "php": ">=7.1.0 || >=7.2.0",
         "illuminate/support": "~5.3 || ^6.0"
     },
     "require-dev": {

--- a/src/migrations/2014_09_27_212641_create_versions_table.php
+++ b/src/migrations/2014_09_27_212641_create_versions_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 

--- a/tests/VersionableTest.php
+++ b/tests/VersionableTest.php
@@ -11,7 +11,7 @@ use Mpociot\Versionable\VersionableTrait;
 class VersionableTest extends VersionableTestCase
 {
 
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
         Auth::clearResolvedInstances();

--- a/tests/VersionableTestCase.php
+++ b/tests/VersionableTestCase.php
@@ -2,7 +2,7 @@
 
 abstract class VersionableTestCase extends \Orchestra\Testbench\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This pull request adds support for laravel 6.0 in composer

Also adds support for PHP 7.2 and 7.1 as Laravel 6.0 requires PHP 7.2

Finally tests where slightly modified in order to be compatible with interfaces.

Greetings