### PR TITLE
Save a COUNT query if all records should be kept

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -195,17 +195,20 @@ trait VersionableTrait
     private function purgeOldVersions()
     {
         $keep = isset($this->keepOldVersions) ? $this->keepOldVersions : 0;
-        $count = $this->versions()->count();
-
-        if ((int)$keep > 0 && $count > $keep) {
-            $oldVersions = $this->versions()
-                ->latest()
-                ->take($count)
-                ->skip($keep)
-                ->get()
-                ->each(function ($version) {
-                $version->delete();
-            });
+        
+        if ((int)$keep > 0) {
+            $count = $this->versions()->count();
+            
+            if ($count > $keep) {
+                $oldVersions = $this->versions()
+                    ->latest()
+                    ->take($count)
+                    ->skip($keep)
+                    ->get()
+                    ->each(function ($version) {
+                    $version->delete();
+                });
+            }
         }
     }
 


### PR DESCRIPTION
This query turned out to be the bottleneck on a project of mine. If you intend to keep all versions there is no need to count them.