### PR TITLE
Add Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mpociot/versionable",
     "license": "MIT",
-    "description": "Allows to create Laravel 4 / 5 / 6 Model versioning and restoring",
+    "description": "Allows to create Laravel 4 / 5 / 6 / 7 Model versioning and restoring",
     "keywords": [
         "model",
         "laravel",
@@ -22,13 +22,13 @@
         "source": "https://github.com/mpociot/versionable"
     },
     "require": {
-        "php": ">=7.1.0 || >=7.2.0",
-        "illuminate/support": "~5.3 || ^6.0"
+        "php": ">=7.1.0 || >=7.2.5",
+        "illuminate/support": "~5.3 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "7.*",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^3.7"
+        "orchestra/testbench": "^3.1"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
         "illuminate/support": "~5.3 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.*",
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^3.1"
+        "orchestra/testbench": "^3.1 || ^4.0 || ^5.0"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="true"
-         stopOnFailure="true"
-         syntaxCheck="false">
+         stopOnFailure="true">
     <testsuites>
         <testsuite name="Versionable Suite">
             <directory>tests/</directory>

--- a/src/Mpociot/Versionable/Providers/ServiceProvider.php
+++ b/src/Mpociot/Versionable/Providers/ServiceProvider.php
@@ -26,5 +26,7 @@ class ServiceProvider extends LaravelServiceProvider
         $this->publishes([
             __DIR__.'/../../../config/config.php' => config_path('versionable.php'),
         ], 'config');
+
+        $this->loadMigrationsFrom(__DIR__.'/../../../migrations');
     }
 }


### PR DESCRIPTION
This pull request fixes #57, #37, #25.

- Update `composer.json` dependency versions to add support for Laravel 7, `phpunit` 9, and `testbench` 5.
- Remove `syntaxCheck` option from `phpunit.xml` (which seems to be invalid now).
- Add `loadMigrationsFrom` to the service provider to automatically expose the migrations. Preferred this approach which is shown in the [Laravel 7.x docs](https://laravel.com/docs/7.x/packages#migrations) instead of making the user manually publish the migrations, as was proposed in #40 and #45, even though that was two years ago (!).

Thanks for your contributions, @stojankukrika, @aruszala, @AngelOD, @spresnac, @commadore and @therobfonz.

Party! 🥳