### PR TITLE
Set offset to zero (0) when reading model stream.

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -48,7 +48,7 @@ class Version extends Eloquent
     public function getModel()
     {
         $modelData = is_resource($this->model_data)
-            ? stream_get_contents($this->model_data)
+            ? stream_get_contents($this->model_data,-1,0)
             : $this->model_data;
 
         $model = new $this->versionable_type();


### PR DESCRIPTION
If using a binary field - and $this->model_data is a resource,
set the offset when reading the stream to the begining (offset 0)
each time, rather than rely on the current position.

This fixes a bug where getModel() can only be called once.

Without this, subsequent calls to getModel cuase an error as
stream_get_contents returns an empty string. The stream position is
at the end. This in turn causes unserialize to return false, causing
an error in $model->fill.