### PR TITLE
Enable migrations publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Run the migrations.
 php artisan migrate --path=vendor/mpociot/versionable/src/migrations
 ```
 
+Alternatively, publish the migrations.
+
+```
+php artisan vendor:publish --provider="Mpociot\Versionable\Providers\ServiceProvider" --tag="migrations"
+```
+
+Then customize and run them.
+
+```
+php artisan migrate
+```
+
 <a name="usage" />
 
 ## Usage

--- a/src/Mpociot/Versionable/Providers/ServiceProvider.php
+++ b/src/Mpociot/Versionable/Providers/ServiceProvider.php
@@ -27,6 +27,10 @@ class ServiceProvider extends LaravelServiceProvider
             __DIR__.'/../../../config/config.php' => config_path('versionable.php'),
         ], 'config');
 
+        $this->publishes([
+            __DIR__ . '/../../../migrations/' => database_path('/migrations'),
+        ], 'migrations');
+
         // $this->loadMigrationsFrom(__DIR__.'/../../../migrations');
     }
 }


### PR DESCRIPTION
This pull request enables the publication of `versionable` migrations for customization before running them.

- Added alternative instructions to README.md
- Added migration publish code to service provider