### PR TITLE
Added morph mapping to version model

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -173,7 +173,7 @@ trait VersionableTrait
             $class                     = $this->getVersionClass();
             $version                   = new $class();
             $version->versionable_id   = $this->getKey();
-            $version->versionable_type = get_class($this);
+            $version->versionable_type = method_exists($this, 'getMorphClass') ? $this->getMorphClass() : get_class($this);
             $version->user_id          = $this->getAuthUserId();
             $version->model_data       = serialize($this->attributesToArray());
 


### PR DESCRIPTION
This is related to the issue described here:

https://github.com/mpociot/versionable/issues/31

Currently, the `VersionableTrait` manually adds the versionable_type property by using get_class which returns the class name.  

When `VersionableTrait` uses morphMany() Laravel will generate the query that includes the morphed class (if you've used custom polymorphic types as described here: https://laravel.com/docs/8.x/eloquent-relationships#custom-polymorphic-types) which will be the incorrect query resulting in no versions available.

