### PR TITLE
Allow versioning of hidden fields in model_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,28 @@ class User extends Model {
 }
 ```
 
+<a name="hiddenFields" />
+
+### Hidden fields
+
+There are times you might want to include hidden fields in the version data. You might have hidden the fields with the `visible` or `hidden` properties in your model.
+
+You can have those fields that are typically hidden in the rest of your project saved in the version data by adding them to the `versionedHiddenFields` property of the versionable model.
+
+```php
+class User {
+
+    use VersionableTrait;
+
+    // Typically hidden fields
+    protected $hidden = ['email', 'password'];
+
+    // Save these hidden fields
+    protected $versionedHiddenFields = ['email', 'password'];
+
+}
+```
+
 <a name="maximum" />
 
 ### Maximum number of stored versions

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -176,7 +176,7 @@ trait VersionableTrait
             $version->versionable_type = get_class($this);
             $version->user_id          = $this->getAuthUserId();
             
-            $versionedHiddenFields = isset($this->versionedHiddenFields) ? $this->versionedHiddenFields : [];
+            $versionedHiddenFields = $this->versionedHiddenFields ?? [];
             $this->makeVisible($versionedHiddenFields);
             $version->model_data       = serialize($this->attributesToArray());
             $this->makeHidden($versionedHiddenFields);

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -175,7 +175,11 @@ trait VersionableTrait
             $version->versionable_id   = $this->getKey();
             $version->versionable_type = get_class($this);
             $version->user_id          = $this->getAuthUserId();
+            
+            $versionedHiddenFields = isset($this->versionedHiddenFields) ? $this->versionedHiddenFields : [];
+            $this->makeVisible($versionedHiddenFields);
             $version->model_data       = serialize($this->attributesToArray());
+            $this->makeHidden($versionedHiddenFields);
 
             if (!empty( $this->reason )) {
                 $version->reason = $this->reason;

--- a/tests/VersionableTest.php
+++ b/tests/VersionableTest.php
@@ -507,6 +507,31 @@ class VersionableTest extends VersionableTestCase
 
         $this->assertEquals( $name_v3, $model->name );
     }
+
+    public function testAllowHiddenFields() {
+        $user = new TestHiddenFieldsUser();
+        $user->name = "Marcel";
+        $user->email = "m.pociot@test.php";
+        $user->password = "12345";
+        $user->save();
+        sleep(1);
+
+        $user->name = "John";
+        $user->email = "j.barlow@test.php";
+        $user->password = "6789";
+        $user->save();
+        sleep(1);
+
+        $diff = $user->previousVersion()->diff();
+
+        $this->assertArrayHasKey('email', $diff);
+        $this->assertArrayHasKey('password', $diff);
+        $this->assertEquals( 'John', $diff['name'] );
+        $this->assertEquals( 'j.barlow@test.php', $diff['email'] );
+        $this->assertEquals( '6789', $diff['password'] );
+
+        $this->assertArrayNotHasKey('password', $user->toArray());
+    }
  
 }
 
@@ -564,3 +589,12 @@ class ModelWithJsonField extends Model
     protected $casts = ['json_field' => 'array'];
 }
 
+class TestHiddenFieldsUser extends \Illuminate\Foundation\Auth\User {
+    use \Mpociot\Versionable\VersionableTrait;
+
+    protected $table = "users";
+
+    protected $hidden = ['email', 'password'];
+
+    protected $versionedHiddenFields = ['email', 'password'];
+}


### PR DESCRIPTION
Sometimes, I want to see the version changes in attributes that have been hidden from the rest of the application using `hidden` and `visible` eloquent properties.

This pull request provides an override array that makes visible attributes that should be versioned even though they have been configured to be hidden.