### PR TITLE
Get actual class name from morph map

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -51,7 +51,8 @@ class Version extends Eloquent
             ? stream_get_contents($this->model_data,-1,0)
             : $this->model_data;
 
-        $model = new $this->versionable_type();
+        $className = self::getActualClassNameForMorph($this->versionable_type);
+        $model = new $className();
         $model->unguard();
         $model->fill(unserialize($modelData));
         $model->exists = true;

--- a/tests/VersionableTest.php
+++ b/tests/VersionableTest.php
@@ -1,12 +1,13 @@
 <?php
 
+use Mockery as m;
 use Carbon\Carbon;
+use Mpociot\Versionable\Version;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
-use Mockery as m;
 use Illuminate\Database\Eloquent\Model;
-use Mpociot\Versionable\Version;
 use Mpociot\Versionable\VersionableTrait;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class VersionableTest extends VersionableTestCase
 {
@@ -512,6 +513,21 @@ class VersionableTest extends VersionableTestCase
         $this->assertEquals( '6789', $diff['password'] );
 
         $this->assertArrayNotHasKey('password', $user->toArray());
+    }
+
+    public function testWhereModelHasMorphMap()
+    {
+        Relation::morphMap(['users' => TestVersionableUser::class]);
+        $user = new TestVersionableUser();
+        $user->name = "Test";
+        $user->email = "example@test.php";
+        $user->password = "12345";
+        $user->last_login = $user->freshTimestamp();
+        $user->save();
+
+        $version = $user->currentVersion();
+        $this->assertEquals( $user->attributesToArray(), $version->getModel()->attributesToArray() );
+        Relation::morphMap([], false);
     }
  
 }


### PR DESCRIPTION
#79 introduced an bug with the `getModel()` method.  `getModel()` was depending on the versionable_type property to be the actual class name and not a morph class (https://github.com/mpociot/versionable/blob/master/src/Mpociot/Versionable/Version.php#L48)

This PR update the getModel() method to use the actual class name instead and adds a test using a morph map.