### PR TITLE
Decouple version save logic into separate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,20 @@ $user->update([
 ]);
 ```
 
+<a name="createInitialVersion" />
+
+### Create initial version for an existing model
+
+When you integrate versionable package in an existing project, you might want to create initial versions for the existing models
+without making any actual changes.
+
+This can be achieved by using the `saveVersion` method on the versionable model.
+
+```php
+$user = User::find(1);
+$user->saveVersion();
+```
+
 <a name="differentVersionTable" />
 
 ### Use different version table

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -155,7 +155,7 @@ trait VersionableTrait
     }
 
     /**
-     * Save a new version.
+     * Save a new version if it is valid for saving.
      * @return void
      */
     protected function versionablePostSave()
@@ -168,25 +168,34 @@ trait VersionableTrait
             ( $this->versioningEnabled === true && !$this->updating && !is_null($this->versionableDirtyData) && count($this->versionableDirtyData))
         ) {
             // Save a new version
-            $class                     = $this->getVersionClass();
-            $version                   = new $class();
-            $version->versionable_id   = $this->getKey();
-            $version->versionable_type = method_exists($this, 'getMorphClass') ? $this->getMorphClass() : get_class($this);
-            $version->user_id          = $this->getAuthUserId();
-            
-            $versionedHiddenFields = $this->versionedHiddenFields ?? [];
-            $this->makeVisible($versionedHiddenFields);
-            $version->model_data       = serialize($this->attributesToArray());
-            $this->makeHidden($versionedHiddenFields);
-
-            if (!empty( $this->reason )) {
-                $version->reason = $this->reason;
-            }
-
-            $version->save();
+            $this->saveVersion();
 
             $this->purgeOldVersions();
         }
+    }
+
+    /**
+     * Save a new version.
+     * @return void
+     */
+    public function saveVersion()
+    {
+        $class                     = $this->getVersionClass();
+        $version                   = new $class();
+        $version->versionable_id   = $this->getKey();
+        $version->versionable_type = method_exists($this, 'getMorphClass') ? $this->getMorphClass() : get_class($this);
+        $version->user_id          = $this->getAuthUserId();
+
+        $versionedHiddenFields = $this->versionedHiddenFields ?? [];
+        $this->makeVisible($versionedHiddenFields);
+        $version->model_data       = serialize($this->attributesToArray());
+        $this->makeHidden($versionedHiddenFields);
+
+        if (!empty( $this->reason )) {
+            $version->reason = $this->reason;
+        }
+
+        $version->save();
     }
 
     /**


### PR DESCRIPTION
Thank you for the great work on the package! 

I have integrated into an existing project and noticed a functionality we need was missing. So introducing `saveVersion` model for forcing to create a version without any changes.

Example use case through a migration:

```

<?php

use App\Models\CustomerDocument;
use Illuminate\Database\Migrations\Migration;

class CreateVersionsForDocuments extends Migration
{
    public const REASON = 'MIGRATION';

    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        $customerDocuments = CustomerDocument::all();
        foreach($customerDocuments as $customerDocument) {
            if(!$customerDocument->currentVersion()) {
                $customerDocument->setReasonAttribute(self::REASON);
                $customerDocument->saveVersion();
            }
        }
    }

```