### PR TITLE
Adds the option to run the versioning logic within a queue job

### DIFF
--- a/src/Mpociot/Versionable/Jobs/VersionableJob.php
+++ b/src/Mpociot/Versionable/Jobs/VersionableJob.php
@@ -24,7 +24,7 @@ class VersionableJob implements ShouldQueue
     private array $attributes;
     private array $originalAttributes;
 
-    public function __construct(private Model $model, private string $reason)
+    public function __construct(private Model $model, private string|null $reason = null)
     {
         $this->attributes = $this->model->getAttributes();
         $this->originalAttributes = $this->model->getOriginal();

--- a/src/Mpociot/Versionable/Jobs/VersionableJob.php
+++ b/src/Mpociot/Versionable/Jobs/VersionableJob.php
@@ -2,12 +2,16 @@
 
 namespace Mpociot\Versionable\Jobs;
 
+use Adaptor\Core\Classes\ServiceExecutionData;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Mpociot\Versionable\Version;
+use ReflectionException;
 
 class VersionableJob implements ShouldQueue
 {
@@ -16,13 +20,33 @@ class VersionableJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public function __construct(private Model $model)
+    public function __construct(private int $id, private string $modelClass, private array $attributes, private array $originalAttributes)
     {
+//        \Log::info('model', ['id' => $id, 'class' => $modelClass, 'attributes' => $this->attributes, 'original' => $this->originalAttributes]);
     }
 
+    /**
+     * @throws ReflectionException
+     */
     public function handle()
     {
-        // TODO test
-        $this->model->versionablePostSave();
+        $resourceReflection = new \ReflectionClass($this->modelClass);
+        $staticResource = $resourceReflection->newInstanceWithoutConstructor();
+        $model = $staticResource->find($this->id);
+
+        foreach ($this->originalAttributes as $key => $value) {
+            $model->setAttribute($key, $value);
+        }
+
+        $model->syncOriginal();
+
+        foreach ($this->attributes as $key => $value) {
+            $model->setAttribute($key, $value);
+        }
+
+        $model->versionableDirtyData = $model->getDirty();
+        $model->updating             = $model->exists;
+
+        Version::createVersionForModel($model);
     }
 }

--- a/src/Mpociot/Versionable/Jobs/VersionableJob.php
+++ b/src/Mpociot/Versionable/Jobs/VersionableJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mpociot\Versionable\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class VersionableJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(private Model $model)
+    {
+    }
+
+    public function handle()
+    {
+        // TODO test
+        $this->model->versionablePostSave();
+    }
+}

--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -112,8 +112,6 @@ class Version extends Eloquent
             ( $model->versioningEnabled === true && $model->updating && $model->isValidForVersioning() ) ||
             ( $model->versioningEnabled === true && !$model->updating && !is_null($model->versionableDirtyData) && count($model->versionableDirtyData))
         ) {
-            \Log::info('2');
-
             // Save a new version
             $class                     = $model->getVersionClass();
             $version                   = new $class();
@@ -121,20 +119,14 @@ class Version extends Eloquent
             $version->versionable_type = method_exists($model, 'getMorphClass') ? $model->getMorphClass() : get_class($model);
             $version->user_id          = $model->getAuthUserId();
 
-            \Log::info('3');
-
             $versionedHiddenFields = $model->versionedHiddenFields ?? [];
             $model->makeVisible($versionedHiddenFields);
             $version->model_data       = serialize($model->attributesToArray());
             $model->makeHidden($versionedHiddenFields);
 
-            \Log::info('4');
-
             if (!empty( $model->reason )) {
                 $version->reason = $model->reason;
             }
-
-            \Log::info('5');
 
             $version->save();
 

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -48,7 +48,7 @@ trait VersionableTrait
      * Optional reason, why this version was created
      * @var string
      */
-    private $reason;
+    public $reason;
 
     /**
      * Flag that determines if the model allows versioning at all
@@ -163,7 +163,7 @@ trait VersionableTrait
     protected function versionablePostSave()
     {
         if (config('versionable.use_queue', false)) {
-            VersionableJob::dispatch($this->id, get_class($this), $this->getAttributes(), $this->getRawOriginal());
+            VersionableJob::dispatch($this, $this?->reason);
         } else {
             Version::createVersionForModel($this);
         }

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -4,6 +4,7 @@ namespace Mpociot\Versionable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Log;
 use Mpociot\Versionable\Jobs\VersionableJob;
 
 /**
@@ -12,7 +13,6 @@ use Mpociot\Versionable\Jobs\VersionableJob;
  */
 trait VersionableTrait
 {
-
     /**
      * Retrieve, if exists, the property that define that Version model.
      * If no property defined, use the default Version model.
@@ -21,7 +21,7 @@ trait VersionableTrait
      * http://php.net/manual/en/language.oop5.traits.php
      * @return unknown|string
      */
-    protected function getVersionClass()
+    public function getVersionClass()
     {
         if( property_exists( self::class, 'versionClass') ) {
             return $this->versionClass;
@@ -42,7 +42,7 @@ trait VersionableTrait
      *
      * @var array
      */
-    private $versionableDirtyData;
+    public $versionableDirtyData;
 
     /**
      * Optional reason, why this version was created
@@ -54,7 +54,7 @@ trait VersionableTrait
      * Flag that determines if the model allows versioning at all
      * @var bool
      */
-    protected $versioningEnabled = true;
+    public $versioningEnabled = true;
 
     /**
      * @return $this
@@ -163,35 +163,9 @@ trait VersionableTrait
     protected function versionablePostSave()
     {
         if (config('versionable.use_queue', false)) {
-            VersionableJob::dispatch($this);
+            VersionableJob::dispatch($this->id, get_class($this), $this->getAttributes(), $this->getRawOriginal());
         } else {
-            /**
-             * We'll save new versions on updating and first creation
-             */
-            if (
-                ( $this->versioningEnabled === true && $this->updating && $this->isValidForVersioning() ) ||
-                ( $this->versioningEnabled === true && !$this->updating && !is_null($this->versionableDirtyData) && count($this->versionableDirtyData))
-            ) {
-                // Save a new version
-                $class                     = $this->getVersionClass();
-                $version                   = new $class();
-                $version->versionable_id   = $this->getKey();
-                $version->versionable_type = method_exists($this, 'getMorphClass') ? $this->getMorphClass() : get_class($this);
-                $version->user_id          = $this->getAuthUserId();
-
-                $versionedHiddenFields = $this->versionedHiddenFields ?? [];
-                $this->makeVisible($versionedHiddenFields);
-                $version->model_data       = serialize($this->attributesToArray());
-                $this->makeHidden($versionedHiddenFields);
-
-                if (!empty( $this->reason )) {
-                    $version->reason = $this->reason;
-                }
-
-                $version->save();
-
-                $this->purgeOldVersions();
-            }
+            Version::createVersionForModel($this);
         }
     }
 
@@ -200,7 +174,7 @@ trait VersionableTrait
      *
      * @return void
      */
-    private function purgeOldVersions()
+    public function purgeOldVersions()
     {
         $keep = isset($this->keepOldVersions) ? $this->keepOldVersions : 0;
 
@@ -224,7 +198,7 @@ trait VersionableTrait
      *
      * @return bool
      */
-    private function isValidForVersioning()
+    public function isValidForVersioning()
     {
         $dontVersionFields = isset( $this->dontVersionFields ) ? $this->dontVersionFields : [];
         $removeableKeys    = array_merge($dontVersionFields, [$this->getUpdatedAtColumn()]);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -7,6 +7,12 @@ return [
      * Feel free to change this, if you need specific version
      * model logic.
      */
-    'version_model' => \Mpociot\Versionable\Version::class
+    'version_model' => \Mpociot\Versionable\Version::class,
 
+
+    /*
+     * Here you can configure the versioning logic
+     * to be handled within a separate job.
+     */
+    'use_queue' => env('VERSIONING_USE_QUEUE', false)
 ];


### PR DESCRIPTION
These changes make it possible to handle all versioning logic within a queue job.

I don't know if this will be a proper update because this maybe moves the package a bit away from simple and easy. 

I needed it for an application that has a huge load of queue jobs (around 5000 per hour). Most of the time the server load was under 1 (at peak moments 2), but after adding versioning it start hitting 2 (10 on peak moments). I needed to remove the versioning because of this.

Feel free to give me some points to improve if you see fit and are interested in merging. 