### PR TITLE
Fix model with no updated_at or deleted_at columns

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -263,11 +263,13 @@ trait VersionableTrait
      */
     private function isValidForVersioning()
     {
-        $dontVersionFields = isset( $this->dontVersionFields ) ? $this->dontVersionFields : [];
-        $removeableKeys    = array_merge($dontVersionFields, [$this->getUpdatedAtColumn()]);
+        $removeableKeys = isset( $this->dontVersionFields ) ? $this->dontVersionFields : [];
+        if (($updatedAt = $this->getUpdatedAtColumn()) !== null) {
+            $removeableKeys[] = $updatedAt;
+        }
 
-        if (method_exists($this, 'getDeletedAtColumn')) {
-            $removeableKeys[] = $this->getDeletedAtColumn();
+        if (method_exists($this, 'getDeletedAtColumn') && ($deletedAt = $this->getDeletedAtColumn() !== null)) {
+            $removeableKeys[] = $deletedAt;
         }
 
         return ( count(array_diff_key($this->versionableDirtyData, array_flip($removeableKeys))) > 0 );


### PR DESCRIPTION
Laravel allows overriding the column name used for timestamps (by default ``updated_at``/``deleted_at``), or disabling timestamps completely by setting the ``UPDATED_AT`` and ``DELETED_AT`` constants to ``null`` ([docs](https://laravel.com/docs/9.x/eloquent#timestamps)). With strict enough error reporting settings, whenever one of those columns is disabled (e.g. set to ``null``), an ``ErrorException`` is thrown:

https://github.com/mpociot/versionable/blob/9af795757305e54f963a96368dee0cf4a4070b37/src/Mpociot/Versionable/VersionableTrait.php#L273
```
ErrorException: array_flip(): Can only flip string and integer values, entry skipped
```

The pull request adds checks to ensure the column names for timestamps is valid/not null.