### PR TITLE
Fix parentheses for assignment

### DIFF
--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -268,7 +268,7 @@ trait VersionableTrait
             $removeableKeys[] = $updatedAt;
         }
 
-        if (method_exists($this, 'getDeletedAtColumn') && ($deletedAt = $this->getDeletedAtColumn() !== null)) {
+        if (method_exists($this, 'getDeletedAtColumn') && ($deletedAt = $this->getDeletedAtColumn()) !== null) {
             $removeableKeys[] = $deletedAt;
         }
 


### PR DESCRIPTION
I think I broke something. 💀 

I guess that's why performing [assignments in conditional expressions](https://wiki.sei.cmu.edu/confluence/display/java/EXP51-J.+Do+not+perform+assignments+in+conditional+expressions) are a bad idea. Or why people should not be working on Sundays. Or why I should just get some rest. Or all of the above.

I just noticed because we updated the library and one of our test suites suddenly failed.

I'm so sorry.
