### PR TITLE
[fix] models being reguarded when they are already unguarded

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -53,10 +53,12 @@ class Version extends Eloquent
 
         $className = self::getActualClassNameForMorph($this->versionable_type);
         $model = new $className();
-        $model->unguard();
-        $model->fill(unserialize($modelData));
-        $model->exists = true;
-        $model->reguard();
+        
+        $model->unguarded(function() use ($model){
+            $model->fill(unserialize($modelData));
+            $model->exists = true;    
+        });
+        
         return $model;
     }
 


### PR DESCRIPTION
This PR will fix this code

```php
        $model->unguard();
        $model->fill(unserialize($modelData));
        $model->exists = true;
        $model->reguard();
```

that reguards all models even if `Model::unguard()` has been called in a service provider

with the proposed fix, this won't happen anymore


