### PR TITLE
PHP Deprecated:  Mpociot\Versionable\Version::diff(): Implicitly mark…

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -85,7 +85,7 @@ class Version extends Eloquent
      * @param Version|null $againstVersion
      * @return array
      */
-    public function diff(Version $againstVersion = null)
+    public function diff(?Version $againstVersion = null)
     {
         $model = $this->getModel();
         $diff  = $againstVersion ? $againstVersion->getModel() : $this->versionable()->withTrashed()->first()->currentVersion()->getModel();


### PR DESCRIPTION
This fixes an php8.4 deprecated error


```
PHP message: PHP Deprecated:  Mpociot\Versionable\Version::diff(): Implicitly marking parameter $againstVersion as nullable is deprecated, the explicit nullable type must be used instead
```